### PR TITLE
crtime: add monotonic time

### DIFF
--- a/crtime/bench_test.go
+++ b/crtime/bench_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crtime
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+)
+
+// Sample results on an Apple M1 (darwin/arm64):
+//
+//	Mono/NowMono-10   41.8ns ± 1%
+//	Mono/time.Now-10  66.8ns ± 3%
+//
+// On Intel(R) Xeon(R) CPU @ 2.80GHz (linux/amd64):
+//
+//	Mono/NowMono-24   49.0ns ± 0%
+//	Mono/time.Now-24  65.1ns ± 0%
+func BenchmarkMono(b *testing.B) {
+	b.Run("NowMono", func(b *testing.B) {
+		var d time.Duration
+		for i := 0; i < b.N; i++ {
+			m := NowMono()
+			d += m.Elapsed()
+		}
+		fmt.Fprint(io.Discard, d)
+	})
+	b.Run("time.Now", func(b *testing.B) {
+		var d time.Duration
+		for i := 0; i < b.N; i++ {
+			t := time.Now()
+			d += time.Since(t)
+		}
+		fmt.Fprint(io.Discard, d)
+	})
+}

--- a/crtime/monotonic.go
+++ b/crtime/monotonic.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crtime
+
+import "time"
+
+// Mono represents a moment in time in terms of a monotonic clock. Its value is
+// the duration since the start of the process.
+//
+// Note that if the system doesn't support a monotonic clock, the wall clock is
+// used.
+type Mono time.Duration
+
+// NowMono returns a moment in time in terms of a monotonic clock. It is faster
+// than time.Now which also consults the wall clock.
+func NowMono() Mono {
+	// Note: time.Since reads only the monotonic clock (if it is available).
+	return Mono(time.Since(startTime))
+}
+
+// Elapsed returns the duration that elapsed since m.
+func (m Mono) Elapsed() time.Duration {
+	return time.Duration(NowMono() - m)
+}
+
+// We use startTime as a reference point against which we can call
+// time.Since(). This solution is suggested by the Go runtime code:
+// https://github.com/golang/go/blob/889abb17e125bb0f5d8de61bb80ef15fbe2a130d/src/runtime/time_nofake.go#L19
+var startTime = time.Now()


### PR DESCRIPTION
Add a slightly faster way to measure elapsed time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/crlib/4)
<!-- Reviewable:end -->
