### PR TITLE
crtime: add Mono.ToUTC

### DIFF
--- a/crtime/monotonic.go
+++ b/crtime/monotonic.go
@@ -44,6 +44,18 @@ func (m Mono) Elapsed() time.Duration {
 	return time.Duration(NowMono() - m)
 }
 
+// ToUTC returns the UTC time corresponding to the monotonic time.
+//
+// The time is derived from the current wall clock, adjusted by the difference
+// in the monotonic clock values. Note that if the wall clock has been changed
+// since the Mono value was obtained, the result does not reflect the wall clock
+// at that point in time.
+func (m Mono) ToUTC() time.Time {
+	now := time.Now()
+	adjustment := time.Duration(m) - now.Sub(startTime)
+	return now.UTC().Add(adjustment)
+}
+
 // MonoFromTime converts a time.Time to a Mono value. If the time has a
 // monotonic component, it is used.
 func MonoFromTime(t time.Time) Mono {

--- a/crtime/monotonic_test.go
+++ b/crtime/monotonic_test.go
@@ -30,4 +30,17 @@ func TestMono(t *testing.T) {
 	d := NowMono()
 	require.LE(t, b, c)
 	require.LE(t, c, d)
+
+	t.Run("ToUTC", func(t *testing.T) {
+		const d = 50 * time.Millisecond
+		const tolerance = time.Millisecond
+
+		start := NowMono()
+		expected := time.Now().UnixNano()
+		time.Sleep(d)
+		actual := start.ToUTC().UnixNano()
+		if actual < expected-tolerance.Nanoseconds() || actual > expected+tolerance.Nanoseconds() {
+			t.Fatalf("actual - expected = %s", time.Duration(actual-expected))
+		}
+	})
 }


### PR DESCRIPTION
Add a method to produce a UTC time using the current clock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/crlib/11)
<!-- Reviewable:end -->
