### PR TITLE
github: update macos image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ghworkflow
   pull_request:
     branches:
       - main
@@ -50,7 +51,7 @@ jobs:
     strategy:
       matrix:
         go: ["1.22"]
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The current macos image is deprecated.

Also add a trigger for a special branch so we can test changes to the
workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/crlib/13)
<!-- Reviewable:end -->
