### PR TITLE
add crhumanize library

### DIFF
--- a/crhumanize/bytes.go
+++ b/crhumanize/bytes.go
@@ -1,0 +1,195 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Bytes returns an approximate (within 5%) human-readable representations of a
+// byte value in IEC units.
+//
+// Examples: "1.5 MiB", "21 GiB", "3 B".
+func Bytes[T Integer](bytes T) SafeString {
+	if bytes < 0 {
+		// Note: uint64(-bytes) doesn't work correctly when bytes is the minimum
+		// value for a smaller type.
+		return "-" + bytesUint64(-uint64(bytes), false)
+	}
+	return bytesUint64(uint64(bytes), false)
+}
+
+// BytesCompact returns an approximate (within 5%) human-readable representations of a
+// byte value. It is similar to Bytes but omits the space and the "i" in the
+// units. The units are still base-1024.
+// Examples: "1.5MB", "21GB", "3B".
+func BytesCompact[T Integer](bytes T) SafeString {
+	if bytes < 0 {
+		return "-" + bytesUint64(-uint64(bytes), true)
+	}
+	return bytesUint64(uint64(bytes), true)
+}
+
+func bytesUint64(bytes uint64, compact bool) SafeString {
+	n, scaled := iecUnit(bytes)
+	digits := 0
+	if scaled < 10 {
+		digits = 1
+	}
+	if compact {
+		return SafeString(fmt.Sprintf("%s%sB", Float(scaled, digits), siUnits[n]))
+	}
+	return SafeString(fmt.Sprintf("%s %sB", Float(scaled, digits), iecUnits[n]))
+}
+
+// BytesExact is similar to Bytes, but the result is exact and can be parsed
+// back into the original value. It separates groups of digits in large numbers
+// with commas for readability.
+//
+// It is guaranteed that ParseBytes[T](BytesExact[T](x)) == x for all x.
+//
+// An example when this should be used instead of Bytes is when we are
+// marshaling a configuration value.
+//
+// Examples: "1,234 KiB", "21,000 GiB", "1,000,000 B".
+func BytesExact[T Integer](bytes T) SafeString {
+	if bytes < 0 {
+		return "-" + bytesExactUint64(-uint64(bytes))
+	}
+	return bytesExactUint64(uint64(bytes))
+}
+
+func bytesExactUint64(bytes uint64) SafeString {
+	i := 0
+	if bytes != 0 {
+		for ; i < len(iecUnits)-1 && bytes%1024 == 0; i++ {
+			bytes /= 1024
+		}
+	}
+	valStr := strconv.FormatUint(bytes, 10)
+	var buf strings.Builder
+	buf.Grow(len(valStr)*4/3 + len(iecUnits[i]) + 2)
+
+	// Add commas to make the number more readable.
+	n := 1 + (len(valStr)-1)%3 // length of the first digit group.
+	buf.WriteString(valStr[:n])
+	for i := n; i < len(valStr); i += 3 {
+		buf.WriteByte(',')
+		buf.WriteString(valStr[i : i+3])
+	}
+	buf.WriteByte(' ')
+	buf.WriteString(iecUnits[i])
+	buf.WriteByte('B')
+
+	return SafeString(buf.String())
+}
+
+func ParseBytes[T Integer](s string) (T, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("cannot parse bytes from %q", s)
+	}
+	unsignedType := T(0)-T(1) > T(0)
+	minusSign := false
+	unsignedPart := s
+	if s[0] == '-' {
+		// Type is unsigned.
+		if unsignedType {
+			return T(0), fmt.Errorf("cannot parse non-negative bytes value from %q", s)
+		}
+		minusSign = true
+		unsignedPart = s[1:]
+	}
+	val, err := parseBytesUint64(unsignedPart)
+	if err != nil {
+		return 0, err
+	}
+
+	// Apply negation and convert to T, checking for numeric overflow.
+	result, ok := func() (T, bool) {
+		if minusSign {
+			if val > -math.MinInt64 {
+				return T(0), false
+			}
+			x := -int64(val)
+			result := T(x)
+			if int64(result) != x {
+				return T(0), false
+			}
+			return result, true
+		}
+
+		result := T(val)
+		if unsignedType {
+			if uint64(result) != val {
+				return T(0), false
+			}
+		} else if val > math.MaxInt64 || result < 0 || int64(result) != int64(val) {
+			return T(0), false
+		}
+		return result, true
+	}()
+
+	if !ok {
+		return T(0), fmt.Errorf("cannot parse bytes value from %q (numeric overflow)", s)
+	}
+	return result, nil
+}
+
+func parseBytesUint64(s string) (uint64, error) {
+	numStr := s
+	for i, r := range s {
+		if (r >= '0' && r <= '9') || r == '.' || r == ',' {
+			continue
+		}
+		numStr = s[:i]
+		break
+	}
+	suffix := strings.TrimSpace(s[len(numStr):])
+	suffix = strings.ToUpper(suffix)
+	// Tolerate but don't require ending with B.
+	suffix = strings.TrimSuffix(suffix, "B")
+	unitIdx, _, ok := parseUnit(suffix)
+	if !ok {
+		return 0, fmt.Errorf("cannot parse bytes from %q", s)
+	}
+	scale := uint64(1) << (10 * unitIdx)
+	numStr = strings.ReplaceAll(numStr, ",", "")
+
+	// We want to guarantee exact parsing of integer values, even those too large
+	// to be accurately represented in a float64.
+	if !strings.Contains(numStr, ".") {
+		value, err := strconv.ParseUint(numStr, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse bytes from %q", s)
+		}
+		if value != 0 && scale > math.MaxUint64/value {
+			return 0, fmt.Errorf("cannot parse bytes from %q (numeric overflow)", s)
+		}
+		return scale * value, nil
+	}
+	value, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse bytes from %q", s)
+	}
+	value = math.Round(value * float64(scale))
+	if value > math.MaxUint64 {
+		return 0, fmt.Errorf("cannot parse bytes from %q (numeric overflow)", s)
+	}
+	return uint64(value), nil
+}

--- a/crhumanize/bytes_test.go
+++ b/crhumanize/bytes_test.go
@@ -1,0 +1,252 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import (
+	"math"
+	"math/rand/v2"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBytes(t *testing.T) {
+	tests := []struct {
+		value    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{-1, "-1 B"},
+		{2, "2 B"},
+		{100, "100 B"},
+		{-100, "-100 B"},
+		{900, "900 B"},
+		{1000, "1000 B"},
+		{1023, "1023 B"},
+		{1024, "1 KiB"},
+		{1090, "1.1 KiB"},
+		{2900, "2.8 KiB"},
+		{10100, "9.9 KiB"},
+		{10200, "10 KiB"},
+		{10240, "10 KiB"},
+		{10300, "10 KiB"},
+		{10800, "11 KiB"},
+		{12 << 20, "12 MiB"},
+		{1200 << 20, "1.2 GiB"},
+		{12 << 30, "12 GiB"},
+		{1200 << 30, "1.2 TiB"},
+		{12 << 40, "12 TiB"},
+		{1200 << 40, "1.2 PiB"},
+		{12 << 50, "12 PiB"},
+		{1200 << 50, "1.2 EiB"},
+		{2 << 60, "2 EiB"},
+		{-(2 << 60), "-2 EiB"},
+	}
+	for _, test := range tests {
+		testBytes(t, test.value, test.expected)
+	}
+	// Verify extreme values of various types.
+	testBytes[int16](t, math.MinInt16, "-32 KiB")
+	testBytes[int16](t, math.MaxInt16, "32 KiB", skipParse)
+
+	testBytes[uint16](t, math.MaxUint16, "64 KiB", skipParse)
+
+	testBytes[int32](t, math.MinInt32, "-2 GiB")
+	testBytes[int32](t, math.MaxInt32, "2 GiB", skipParse)
+
+	testBytes[uint32](t, math.MaxUint32, "4 GiB", skipParse)
+
+	testBytes[int64](t, math.MinInt64, "-8 EiB")
+	testBytes[int64](t, math.MaxInt64, "8 EiB", skipParse)
+
+	testBytes[uint64](t, math.MaxUint64, "16 EiB", skipParse)
+}
+
+const skipParse = true
+
+func testBytes[T Integer](t *testing.T, value T, expected string, skipParse ...bool) {
+	t.Helper()
+	result := string(Bytes(value))
+	if result != expected {
+		t.Errorf("Bytes(%d) = %s; expected %s", value, result, expected)
+	}
+	// Compact string should be the same as the expected string but without spaces and "i".
+	expectedCompact := strings.ReplaceAll(expected, " ", "")
+	expectedCompact = strings.ReplaceAll(expectedCompact, "i", "")
+	resultCompact := string(BytesCompact(value))
+	if resultCompact != expectedCompact {
+		t.Errorf("BytesCompact(%d) = %s; expected %s", value, resultCompact, expectedCompact)
+	}
+
+	if len(skipParse) > 0 {
+		// Special case: this value cannot be parsed back.
+		return
+	}
+
+	parsed, err := ParseBytes[T](result)
+	if err != nil {
+		t.Fatalf("could not parse Bytes[%s](%d)=%q: %v", reflect.TypeOf(value), value, result, err)
+	}
+	delta := math.Abs(float64(parsed) - float64(value))
+	if delta > 0.05*math.Abs(float64(value)) {
+		t.Fatalf("invalid parse result on Bytes[%s](%d)=%q: %d", reflect.TypeOf(value), value, result, parsed)
+	}
+	parsed2, err := ParseBytes[T](resultCompact)
+	if err != nil {
+		t.Fatalf("could not parse BytesCompact[%s](%d)=%q: %v", reflect.TypeOf(value), value, resultCompact, err)
+	}
+	if parsed2 != parsed {
+		t.Fatalf("unexpected parse result on BytesCompact[%s](%d)=%q: %d", reflect.TypeOf(value), value, resultCompact, parsed)
+	}
+}
+
+func TestBytesExact(t *testing.T) {
+	tests := []struct {
+		value    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{-1, "-1 B"},
+		{2, "2 B"},
+		{100, "100 B"},
+		{-100, "-100 B"},
+		{900, "900 B"},
+		{1000, "1,000 B"},
+		{1023, "1,023 B"},
+		{1024, "1 KiB"},
+		{1090, "1,090 B"},
+		{2900, "2,900 B"},
+		{10100, "10,100 B"},
+		{10240, "10 KiB"},
+		{1_000_000, "1,000,000 B"},
+		{12 << 20, "12 MiB"},
+		{12<<20 + 1, "12,582,913 B"},
+		{12<<20 + 1024, "12,289 KiB"},
+		{1200 << 20, "1,200 MiB"},
+		{12 << 30, "12 GiB"},
+		{1200 << 30, "1,200 GiB"},
+		{12 << 40, "12 TiB"},
+		{1200 << 40, "1,200 TiB"},
+		{12 << 50, "12 PiB"},
+		{12<<50 + 1, "13,510,798,882,111,489 B"},
+		{1200 << 50, "1,200 PiB"},
+		{2 << 60, "2 EiB"},
+		{-(2 << 60), "-2 EiB"},
+		{math.MaxInt64, "9,223,372,036,854,775,807 B"},
+		{math.MinInt64, "-8 EiB"},
+	}
+	for _, test := range tests {
+		testBytesExact(t, test.value, test.expected)
+	}
+
+	// Verify extreme values of various types.
+	testBytesExact[int16](t, math.MinInt16, "-32 KiB")
+	testBytesExact[int16](t, math.MaxInt16, "32,767 B")
+
+	testBytesExact[uint16](t, math.MaxUint16, "65,535 B")
+
+	testBytesExact[int32](t, math.MinInt32, "-2 GiB")
+	testBytesExact[int32](t, math.MaxInt32, "2,147,483,647 B")
+
+	testBytesExact[uint32](t, math.MaxUint32, "4,294,967,295 B")
+
+	testBytesExact[int64](t, math.MinInt64, "-8 EiB")
+	testBytesExact[int64](t, math.MaxInt64, "9,223,372,036,854,775,807 B")
+
+	testBytesExact[uint64](t, math.MaxUint64, "18,446,744,073,709,551,615 B")
+
+	for i := 0; i < 10000; i++ {
+		n := rand.Uint64()
+		if i%4 == 0 {
+			// Test values around powers of two.
+			n = uint64(1) << (n % 63)
+			n = n + rand.Uint64N(10) - 5
+		}
+		testBytesExactRoundtrip[int8](t, n)
+		testBytesExactRoundtrip[uint8](t, n)
+		testBytesExactRoundtrip[int16](t, n)
+		testBytesExactRoundtrip[uint16](t, n)
+		testBytesExactRoundtrip[int32](t, n)
+		testBytesExactRoundtrip[uint32](t, n)
+		testBytesExactRoundtrip[int64](t, n)
+		testBytesExactRoundtrip[uint64](t, n)
+		testBytesExactRoundtrip[int](t, n)
+		testBytesExactRoundtrip[uint](t, n)
+	}
+}
+
+func testBytesExact[T Integer](t *testing.T, value T, expected string) {
+	t.Helper()
+	result := string(BytesExact(value))
+	if result != expected {
+		t.Errorf("BytesExact(%d) = %s; expected %s", value, result, expected)
+	}
+	parsed, err := ParseBytes[T](result)
+	if err != nil {
+		t.Fatalf("could not parse BytesExact(%d)=%q: %v", value, result, err)
+	}
+	if parsed != value {
+		t.Fatalf("invalid parse result on BytesExact(%d)=%q: %d", value, result, parsed)
+	}
+}
+
+func testBytesExactRoundtrip[T Integer](t *testing.T, valueUint uint64) {
+	value := T(valueUint)
+	t.Helper()
+	result := string(BytesExact[T](value))
+	parsed, err := ParseBytes[T](result)
+	if err != nil {
+		t.Fatalf("could not parse BytesExact(%d)=%q: %v", value, result, err)
+	}
+	if parsed != value {
+		t.Fatalf("invalid parse result on BytesExact(%d)=%q: %d", value, result, parsed)
+	}
+}
+
+func TestParseBytesErrors(t *testing.T) {
+	expectParseErr[uint64](t, "18,446,744,073,709,551,616 B")
+	expectParseErr[uint64](t, "18 EiB")
+	expectParseErr[uint64](t, "123.45 EiB")
+	expectParseErr[uint64](t, "100,000,000,000,000,000,000 B")
+	expectParseErr[int64](t, "9,223,372,036,854,775,808")
+	expectParseErr[int64](t, "-9,223,372,036,854,775,809")
+	expectParseErr[int64](t, "9.1EB")
+
+	expectParseErr[uint32](t, "4,294,967,296")
+	expectParseErr[int32](t, "4,294,967,296")
+	expectParseErr[int32](t, "2GB")
+	expectParseErr[int32](t, "-2.1GB")
+	expectParseErr[int32](t, "-2,147,483,649 B")
+
+	expectParseErr[uint16](t, "65536")
+	expectParseErr[uint16](t, "655361234")
+	expectParseErr[int16](t, "32768")
+	expectParseErr[int16](t, "32KiB")
+	expectParseErr[int16](t, "-32.1KB")
+	expectParseErr[int16](t, "-32769 B")
+
+	expectParseErr[uint8](t, "256")
+	expectParseErr[int8](t, "128")
+	expectParseErr[int8](t, "-129")
+}
+
+func expectParseErr[T Integer](t *testing.T, s string) {
+	if _, err := ParseBytes[T](s); err == nil {
+		t.Helper()
+		t.Errorf("expected error parsing %q", s)
+	}
+}

--- a/crhumanize/count.go
+++ b/crhumanize/count.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import "fmt"
+
+func Count[T Integer](count T) SafeString {
+	if count < 0 {
+		return "-" + Count[T](-count)
+	}
+
+	n, scaled := siUnit(uint64(count))
+	digits := 0
+	if scaled < 10 {
+		digits = 1
+	}
+	return SafeString(fmt.Sprintf("%s%s", Float(scaled, digits), siUnits[n]))
+}

--- a/crhumanize/count_test.go
+++ b/crhumanize/count_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import "testing"
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		value    int64
+		expected string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{-1, "-1"},
+		{2, "2"},
+		{100, "100"},
+		{-100, "-100"},
+		{900, "900"},
+		{1000, "1K"},
+		{1040, "1K"},
+		{1050, "1.1K"},
+		{1900, "1.9K"},
+		{1951, "2K"},
+		{9900, "9.9K"},
+		{9951, "10K"},
+		{10200, "10K"},
+		{10600, "11K"},
+		{12_000_000, "12M"},
+		{1_200_000_000, "1.2G"},
+		{12_000_000_000, "12G"},
+		{1_200_000_000_000, "1.2T"},
+		{12_000_000_000_000, "12T"},
+		{1_200_000_000_000_000, "1.2P"},
+		{12_000_000_000_000_000, "12P"},
+		{1_200_000_000_000_000_000, "1.2E"},
+		{2_000_000_000_000_000_000, "2E"},
+		{-2_000_000_000_000_000_000, "-2E"},
+	}
+	for _, test := range tests {
+		result := string(Count(test.value))
+		if result != test.expected {
+			t.Errorf("Count(%d) = %s; expected %s", test.value, result, test.expected)
+		}
+	}
+}

--- a/crhumanize/float.go
+++ b/crhumanize/float.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import (
+	"strconv"
+	"strings"
+)
+
+func Float(value float64, decimalDigits int) SafeString {
+	s := strconv.FormatFloat(value, 'f', decimalDigits, 64)
+	// Strip trailing zeros.
+	if strings.ContainsRune(s, '.') {
+		for s[len(s)-1] == '0' {
+			s = s[:len(s)-1]
+		}
+		if s[len(s)-1] == '.' {
+			s = s[:len(s)-1]
+		}
+	}
+	return SafeString(s)
+}

--- a/crhumanize/float_test.go
+++ b/crhumanize/float_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import "testing"
+
+func TestFloat(t *testing.T) {
+	tests := []struct {
+		value         float64
+		decimalDigits int
+		expected      string
+	}{
+		{0, 0, "0"},
+		{0, 1, "0"},
+		{0, 1, "0"},
+		{0.1, 1, "0.1"},
+		{0.1, 2, "0.1"},
+		{0.01, 1, "0"},
+		{0.01, 2, "0.01"},
+		{0.01, 4, "0.01"},
+		{1.23456789, 2, "1.23"},
+		{1.23456789, 3, "1.235"},
+		{1.23456789, 3, "1.235"},
+		{123456.7777, 1, "123456.8"},
+		{123456.7777, 2, "123456.78"},
+		{123456.1010, 4, "123456.101"},
+		{123456.1010, 2, "123456.1"},
+		{123456.1010, 1, "123456.1"},
+		{123456.1010, 0, "123456"},
+	}
+
+	for _, test := range tests {
+		result := string(Float(test.value, test.decimalDigits))
+		if result != test.expected {
+			t.Errorf("Float(%f, %d) = %s; expected %s", test.value, test.decimalDigits, result, test.expected)
+		}
+	}
+}

--- a/crhumanize/humanize.go
+++ b/crhumanize/humanize.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crhumanize
+
+import (
+	"math"
+	"math/bits"
+	"strings"
+)
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// SafeString represents a human readable representation of a value. It
+// implements a `SafeValue()` marker method (implementing the
+// github.com/cockroachdb/redact.SafeValue interface) to signal that it
+// represents a string that does not need to be redacted.
+type SafeString string
+
+// SafeValue implements cockroachdb/redact.SafeValue.
+func (fs SafeString) SafeValue() {}
+
+// String implements fmt.Stringer.
+func (fs SafeString) String() string { return string(fs) }
+
+var iecUnits = []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
+var siUnits = []string{"", "K", "M", "G", "T", "P", "E"}
+
+func iecUnit(value uint64) (index int, scaled float64) {
+	n := (max(0, bits.Len64(value)-1)) / 10
+	return n, float64(value) / float64(uint64(1)<<(10*n))
+}
+
+func siUnit(value uint64) (index int, scaled float64) {
+	if value < 10 {
+		return 0, float64(value)
+	}
+	n := int(math.Floor(math.Log10(float64(value)))) / 3
+	return n, float64(value) / math.Pow10(3*n)
+}
+
+func parseUnit(s string) (index int, iec bool, ok bool) {
+	s = strings.ToUpper(s)
+	s, iec = strings.CutSuffix(s, "I")
+	for i := range siUnits {
+		if s == siUnits[i] {
+			if i == 0 && iec {
+				// Just an "i" is not ok.
+				return 0, false, false
+			}
+			return i, iec, true
+		}
+	}
+	return 0, false, false
+}


### PR DESCRIPTION
Add a library that supports `Count()`, `Bytes()` (with a few
variations), and `ParseBytes`.

The goal is to replace the humanize code and libraries in Pebble and CRDB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/crlib/16)
<!-- Reviewable:end -->
